### PR TITLE
#270 Improve name convention checking of `PokaYokeProfileValidator`

### DIFF
--- a/plugins/com.github.tno.pokayoke.uml.profile.util/src/com/github/tno/pokayoke/uml/profile/validation/PokaYokeProfileValidator.java
+++ b/plugins/com.github.tno.pokayoke.uml.profile.util/src/com/github/tno/pokayoke/uml/profile/validation/PokaYokeProfileValidator.java
@@ -104,6 +104,11 @@ public class PokaYokeProfileValidator extends ContextAwareDeclarativeValidator {
     }
 
     @Check
+    private void checkValidModel(Model model) {
+        checkNamingConventions(model, true, true);
+    }
+
+    @Check
     private void checkValidClass(Class clazz) {
         if (!isPokaYokaUmlProfileApplied(clazz)) {
             return;


### PR DESCRIPTION
Closes #270

Now naming conventions are checked of: models, classes, activities, properties, opaque behaviors, enums, and enum literals. (The names of opaque actions were already covered by the checks on activity nodes.) These checks are added over several commits, one check at a time. I've tested all checks individually.