### PR TITLE
#287 Regression tests for UML-to-Cameo fail due to validation errors

### DIFF
--- a/plugins/com.github.tno.pokayoke.transform.uml/resources-test/regressiontests/defaults/expected/input.uml
+++ b/plugins/com.github.tno.pokayoke.transform.uml/resources-test/regressiontests/defaults/expected/input.uml
@@ -104,7 +104,7 @@
           <result xmi:id="62" name="requester" outgoing="39">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </result>
-          <value xmi:type="uml:LiteralString" xmi:id="63" value="OpaqueAction1"/>
+          <value xmi:type="uml:LiteralString" xmi:id="63" value="OpaqueAction1___S4OE4AxCEe-xDvtDM-gL4Q"/>
         </node>
         <node xmi:type="uml:MergeNode" xmi:id="64" incoming="40 46" outgoing="41"/>
         <node xmi:type="uml:OpaqueAction" xmi:id="65" incoming="41" outgoing="42">
@@ -112,7 +112,7 @@
           <outputValue xmi:id="66" name="isActive" outgoing="43">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
           </outputValue>
-          <body>active == 'OpaqueAction1'</body>
+          <body>active == 'OpaqueAction1___S4OE4AxCEe-xDvtDM-gL4Q'</body>
         </node>
         <node xmi:type="uml:DecisionNode" xmi:id="67" incoming="42 43" outgoing="44 46"/>
         <node xmi:type="uml:OpaqueAction" xmi:id="68" incoming="44" outgoing="48">

--- a/plugins/com.github.tno.pokayoke.transform.uml/resources-test/regressiontests/integer/expected/input.uml
+++ b/plugins/com.github.tno.pokayoke.transform.uml/resources-test/regressiontests/integer/expected/input.uml
@@ -94,7 +94,7 @@
           <result xmi:id="50" name="requester" outgoing="27">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </result>
-          <value xmi:type="uml:LiteralString" xmi:id="51" value="MyAction"/>
+          <value xmi:type="uml:LiteralString" xmi:id="51" value="MyAction___CVWrgPGTEe6asLMew-pIxQ"/>
         </node>
         <node xmi:type="uml:MergeNode" xmi:id="52" incoming="28 34" outgoing="29"/>
         <node xmi:type="uml:OpaqueAction" xmi:id="53" incoming="29" outgoing="30">
@@ -102,7 +102,7 @@
           <outputValue xmi:id="54" name="isActive" outgoing="31">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
           </outputValue>
-          <body>active == 'MyAction'</body>
+          <body>active == 'MyAction___CVWrgPGTEe6asLMew-pIxQ'</body>
         </node>
         <node xmi:type="uml:DecisionNode" xmi:id="55" incoming="30 31" outgoing="32 34"/>
         <node xmi:type="uml:OpaqueAction" xmi:id="56" incoming="32" outgoing="36">

--- a/plugins/com.github.tno.pokayoke.transform.uml/src/com/github/tno/pokayoke/transform/uml/UMLTransformer.java
+++ b/plugins/com.github.tno.pokayoke.transform.uml/src/com/github/tno/pokayoke/transform/uml/UMLTransformer.java
@@ -97,7 +97,8 @@ public class UMLTransformer {
         ValidationHelper.validateModel(model);
 
         Preconditions.checkArgument(!cifContext.hasOpaqueBehaviors(), "Opaque behaviors are unsupported.");
-        Preconditions.checkArgument(!cifContext.hasConstraints(), "Constraints are unsupported.");
+        Preconditions.checkArgument(!cifContext.hasConstraints(c -> !CifContext.isPrimitiveTypeConstraint(c)),
+                "Only type constraints are supported.");
         Preconditions.checkArgument(!cifContext.hasAbstractActivities(), "Abstract activities are unsupported.");
 
         Preconditions.checkArgument(model.getPackagedElement(LOCK_CLASS_NAME) == null,

--- a/plugins/com.github.tno.pokayoke.transform.uml2gal/src/com/github/tno/pokayoke/transform/uml2gal/Uml2GalTranslator.java
+++ b/plugins/com.github.tno.pokayoke.transform.uml2gal/src/com/github/tno/pokayoke/transform/uml2gal/Uml2GalTranslator.java
@@ -120,7 +120,8 @@ public class Uml2GalTranslator {
 
         // Check transformation preconditions.
         Preconditions.checkArgument(!cifContext.hasOpaqueBehaviors(), "Opaque behaviors are unsupported.");
-        Preconditions.checkArgument(!cifContext.hasConstraints(), "Constraints are unsupported.");
+        Preconditions.checkArgument(!cifContext.hasConstraints(c -> !CifContext.isPrimitiveTypeConstraint(c)),
+                "Only type constraints are supported.");
         Preconditions.checkArgument(!cifContext.hasAbstractActivities(), "Abstract activities are unsupported.");
 
         // Translate the given model by visiting and translating all its elements.

--- a/plugins/com.github.tno.pokayoke.uml.profile.util/src/com/github/tno/pokayoke/uml/profile/cif/CifContext.java
+++ b/plugins/com.github.tno.pokayoke.uml.profile.util/src/com/github/tno/pokayoke/uml/profile/cif/CifContext.java
@@ -5,17 +5,22 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.lsat.common.queries.QueryableIterable;
 import org.eclipse.uml2.uml.Activity;
+import org.eclipse.uml2.uml.Behavior;
+import org.eclipse.uml2.uml.Class;
 import org.eclipse.uml2.uml.Constraint;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Enumeration;
 import org.eclipse.uml2.uml.EnumerationLiteral;
+import org.eclipse.uml2.uml.IntervalConstraint;
 import org.eclipse.uml2.uml.Model;
 import org.eclipse.uml2.uml.NamedElement;
 import org.eclipse.uml2.uml.OpaqueBehavior;
+import org.eclipse.uml2.uml.PrimitiveType;
 import org.eclipse.uml2.uml.Property;
 import org.eclipse.uml2.uml.UMLPackage;
 
@@ -57,7 +62,8 @@ public class CifContext {
      * @return All found contextual elements.
      */
     public static QueryableIterable<NamedElement> queryUniqueNameElements(Model model) {
-        return queryContextElements(model).select(e -> !e.eClass().equals(UMLPackage.Literals.ACTIVITY));
+        Set<EClass> exclude = Set.of(UMLPackage.Literals.ACTIVITY, UMLPackage.Literals.CONSTRAINT);
+        return queryContextElements(model).select(e -> !exclude.contains(e.eClass()));
     }
 
     private final Map<String, NamedElement> contextElements;
@@ -128,8 +134,24 @@ public class CifContext {
         return null;
     }
 
-    public boolean hasConstraints() {
-        return getAllElements().stream().anyMatch(Constraint.class::isInstance);
+    public boolean hasConstraints(Predicate<Constraint> predicate) {
+        return getAllElements().stream().anyMatch(e -> e instanceof Constraint c && predicate.test(c));
+    }
+
+    public static boolean isActivityPostconditionConstraint(Constraint constraint) {
+        return constraint.getContext() instanceof Activity a && a.getPostconditions().contains(constraint);
+    }
+
+    public static boolean isClassConstraint(Constraint constraint) {
+        return constraint.getContext() instanceof Class clazz && !(clazz instanceof Behavior);
+    }
+
+    public static boolean isOptimalityConstraint(Constraint constraint) {
+        return constraint.getContext() instanceof Activity && constraint instanceof IntervalConstraint;
+    }
+
+    public static boolean isPrimitiveTypeConstraint(Constraint constraint) {
+        return constraint.getContext() instanceof PrimitiveType;
     }
 
     public boolean hasAbstractActivities() {


### PR DESCRIPTION
Closes #287

- Updated `PokaYokeProfileValidator#checkValidConstraint` to have separate checks for the different kinds of constraints we have.
- Updated `CifContext#queryUniqueNameElements` to exclude all constraints from the name uniqueness check. That's because now we can have multiple constraints named e.g. "min" or "max". 
- Updated the UML-to-Cameo/GAL precondition checks to allow constraints only on primitive types.
- Updated the regression test UML files with values that weren't included in #286 due to the failing regression tests.