### PR TITLE
#495 Adding missing plugins to feature

### DIFF
--- a/features/com.github.tno.pokayoke.feature/feature.xml
+++ b/features/com.github.tno.pokayoke.feature/feature.xml
@@ -87,7 +87,7 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="com.github.tno.pokayoke.transform.uml2gal"
          download-size="0"
@@ -125,6 +125,20 @@
 
    <plugin
          id="com.github.tno.pokayoke.transform.activitysynthesis"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.github.tno.pokayoke.transform.flatten"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.github.tno.pokayoke.transform.petrify"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Closes #495.

Plugin `transform.tests.common` is also not in the feature, but I did not include that one.