### PR TITLE
#519 Restored ITS-Tools stable release 02-2024

### DIFF
--- a/releng/com.github.tno.pokayoke.releng.target/com.github.tno.pokayoke.releng.target.target
+++ b/releng/com.github.tno.pokayoke.releng.target/com.github.tno.pokayoke.releng.target.target
@@ -33,7 +33,7 @@
             <unit id="org.apache.ws.commons.axiom.axiom-dom" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://lip6.github.io/ITSTools/"/>
+            <repository location="https://tno.github.io/ITSTools/"/>
             <unit id="fr.lip6.move.gal.feature.sdk.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
A recent update of ITStools requites Eclipse 2025-03, and ITStools does not provide older versions on their update site. So I forked their git repository, see https://github.com/TNO/ITSTools and I have restored their [ITS-Tools stable release 02-2024](https://github.com/lip6/ITSTools/releases/tag/v01022024) on the forked pages, see https://github.com/TNO/ITSTools/tree/gh-pages and https://tno.github.io/ITSTools/.

Closes #519