### PR TITLE
#629 Vertical scaling from finalized UML model to guard computation

### DIFF
--- a/plugins/com.github.tno.pokayoke.transform.app/src/com/github/tno/pokayoke/transform/app/FullSynthesisApp.java
+++ b/plugins/com.github.tno.pokayoke.transform.app/src/com/github/tno/pokayoke/transform/app/FullSynthesisApp.java
@@ -303,7 +303,7 @@ public class FullSynthesisApp {
 
         // Post-process the activity to simplify it.
         Path umlSimplifiedOutputPath = outputFolderPath.resolve(filePrefix + ".17.simplified.uml");
-        PostProcessActivity.simplify(activity);
+        PostProcessActivity.simplify(activity, tracker);
         FileHelper.storeModel(activity.getModel(), umlSimplifiedOutputPath.toString());
 
         // Post-process the activity to remove the names of edges and nodes.

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -138,6 +138,10 @@ public class PostProcessActivity {
                 // Get the kind of action, and finalize the opaque action accordingly.
                 ActionKind actionKind = tracker.getActionKind(action);
                 RedefinableElement umlElement = tracker.getUmlElement(action);
+
+                // Get the name for the finalized UML element. If the current node is a duplicate of a node belonging to
+                // a called concrete activity, get a new name (without double underscores); if the current node has been
+                // generated for the synthesized activity, keep its current name.
                 String newElementName = getNewElementName(umlElement, activity);
 
                 switch (actionKind) {
@@ -325,17 +329,19 @@ public class PostProcessActivity {
     }
 
     /**
-     * Creates a new name for the given UML element and its container activity, without the use of double underscores.
+     * Creates a new name for the given UML element if it does not belong to the synthesized activity. The new name is
+     * the concatenation of the UML element's container activity and its current name, without the use of double
+     * underscores.
      *
      * @param umlElement The UML element to rename.
-     * @param activity The container activity.
+     * @param synthesizedActivity The synthesized activity.
      * @return The new element's name.
      */
-    private static String getNewElementName(RedefinableElement umlElement, Activity activity) {
-        if (umlElement instanceof OpaqueBehavior || umlElement.eContainer().equals(activity)) {
-            return umlElement.getName();
-        } else {
+    private static String getNewElementName(RedefinableElement umlElement, Activity synthesizedActivity) {
+        if (umlElement.eContainer() instanceof Activity && !umlElement.eContainer().equals(synthesizedActivity)) {
             return ((Activity)umlElement.eContainer()).getName() + "_" + umlElement.getName();
+        } else {
+            return umlElement.getName();
         }
     }
 }

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -329,9 +329,9 @@ public class PostProcessActivity {
     }
 
     /**
-     * Creates a new name for the given UML element if it does not belong to the synthesized activity. The new name is
-     * the concatenation of the UML element's container activity and its current name, without the use of double
-     * underscores.
+     * Creates a new name for the given UML element in case that element belongs to an activity but not the given
+     * synthesized activity. The new name is the concatenation of the UML element's container activity and its current
+     * name, without the use of double underscores.
      *
      * @param umlElement The UML element to rename.
      * @param synthesizedActivity The synthesized activity.

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -333,11 +333,14 @@ public class PostProcessActivity {
      * synthesized activity. The new name is the concatenation of the UML element's container activity and its current
      * name, without the use of double underscores.
      *
-     * @param umlElement The UML element to rename.
+     * @param umlElement The UML element to rename. Its name should not contain double underscores.
      * @param synthesizedActivity The synthesized activity.
      * @return The new element's name.
      */
     private static String getNewElementName(RedefinableElement umlElement, Activity synthesizedActivity) {
+        Verify.verify(!umlElement.getName().contains("__"),
+                "The name of UML element " + umlElement.getName() + " contains double underscores.");
+
         if (umlElement.eContainer() instanceof Activity activity && !activity.equals(synthesizedActivity)) {
             return activity.getName() + "_" + umlElement.getName();
         } else {

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -102,15 +102,16 @@ public class PostProcessActivity {
      * Simplifies the given activity.
      *
      * @param activity The activity to simplify, which is modified in-place.
+     * @param tracker The synthesis chain tracker.
      */
-    public static void simplify(Activity activity) {
+    public static void simplify(Activity activity, SynthesisChainTracking tracker) {
         while (true) {
             boolean changed = false;
 
-            changed |= RedundantDecisionMergePattern.findAndRewriteAll(activity);
-            changed |= RedundantDecisionForkMergePattern.findAndRewriteAll(activity);
-            changed |= EquivalentActionsIntoMergePattern.findAndRewriteAll(activity);
-            changed |= DoubleMergePattern.findAndRewriteAll(activity);
+            changed |= RedundantDecisionMergePattern.findAndRewriteAll(activity, tracker);
+            changed |= RedundantDecisionForkMergePattern.findAndRewriteAll(activity, tracker);
+            changed |= EquivalentActionsIntoMergePattern.findAndRewriteAll(activity, tracker);
+            changed |= DoubleMergePattern.findAndRewriteAll(activity, tracker);
 
             if (!changed) {
                 break;

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -338,8 +338,8 @@ public class PostProcessActivity {
      * @return The new element's name.
      */
     private static String getNewElementName(RedefinableElement umlElement, Activity synthesizedActivity) {
-        if (umlElement.eContainer() instanceof Activity && !umlElement.eContainer().equals(synthesizedActivity)) {
-            return ((Activity)umlElement.eContainer()).getName() + "_" + umlElement.getName();
+        if (umlElement.eContainer() instanceof Activity activity && !activity.equals(synthesizedActivity)) {
+            return activity.getName() + "_" + umlElement.getName();
         } else {
             return umlElement.getName();
         }

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -138,6 +138,7 @@ public class PostProcessActivity {
                 // Get the kind of action, and finalize the opaque action accordingly.
                 ActionKind actionKind = tracker.getActionKind(action);
                 RedefinableElement umlElement = tracker.getUmlElement(action);
+                String newElementName = getNewElementName(umlElement, activity);
 
                 switch (actionKind) {
                     case COMPLETE_OPAQUE_BEHAVIOR -> {
@@ -145,7 +146,7 @@ public class PostProcessActivity {
                         CallBehaviorAction callAction = UML_FACTORY.createCallBehaviorAction();
                         callAction.setBehavior((OpaqueBehavior)umlElement);
                         callAction.setActivity(activity);
-                        callAction.setName(action.getName());
+                        callAction.setName(newElementName);
 
                         // Store the finalized UML element in the synthesis chain tracker.
                         tracker.addFinalizedUmlElement(callAction, action);
@@ -162,7 +163,7 @@ public class PostProcessActivity {
                     case START_OPAQUE_BEHAVIOR -> {
                         // The action is the start of a non-merged non-atomic opaque behavior. Add its guards to the
                         // opaque action. Set the atomicity property to 'true'.
-                        action.setName(umlElement.getName() + UmlToCifTranslator.START_ACTION_SUFFIX);
+                        action.setName(newElementName + UmlToCifTranslator.START_ACTION_SUFFIX);
                         PokaYokeUmlProfileUtil.setAtomic(action, true);
                         PokaYokeUmlProfileUtil.setGuard(action, PokaYokeUmlProfileUtil.getGuard(umlElement));
 
@@ -183,7 +184,7 @@ public class PostProcessActivity {
                         CallBehaviorAction callAction = UML_FACTORY.createCallBehaviorAction();
                         callAction.setBehavior(((CallBehaviorAction)umlElement).getBehavior());
                         callAction.setActivity(activity);
-                        callAction.setName(action.getName());
+                        callAction.setName(newElementName);
 
                         // Store the finalized UML element in the synthesis chain tracker.
                         tracker.addFinalizedUmlElement(callAction, action);
@@ -199,7 +200,7 @@ public class PostProcessActivity {
                         // The opaque action represents the start of a non-rewritten call behavior that calls a
                         // non-atomic opaque behavior. Add the guards of the called opaque behavior to the opaque
                         // action. Set the atomicity property to 'true'.
-                        action.setName(action.getName() + UmlToCifTranslator.START_ACTION_SUFFIX);
+                        action.setName(newElementName + UmlToCifTranslator.START_ACTION_SUFFIX);
                         PokaYokeUmlProfileUtil.setAtomic(action, true);
                         PokaYokeUmlProfileUtil.setGuard(action,
                                 PokaYokeUmlProfileUtil.getGuard(((CallBehaviorAction)umlElement).getBehavior()));
@@ -220,7 +221,7 @@ public class PostProcessActivity {
                         PokaYokeUmlProfileUtil.setGuard(action, PokaYokeUmlProfileUtil.getGuard(umlElement));
                         PokaYokeUmlProfileUtil.setEffects(action, PokaYokeUmlProfileUtil.getEffects(umlElement));
                         PokaYokeUmlProfileUtil.setAtomic(action, PokaYokeUmlProfileUtil.isAtomic(umlElement));
-                        action.setName(action.getName());
+                        action.setName(newElementName);
 
                         // Store the finalized UML element in the synthesis chain tracker.
                         tracker.addFinalizedUmlElement(action, action);
@@ -232,7 +233,7 @@ public class PostProcessActivity {
                         // Add the original UML element's guard. Set the atomicity property to 'true'.
                         PokaYokeUmlProfileUtil.setGuard(action, PokaYokeUmlProfileUtil.getGuard(umlElement));
                         PokaYokeUmlProfileUtil.setAtomic(action, true);
-                        action.setName(action.getName() + UmlToCifTranslator.START_ACTION_SUFFIX);
+                        action.setName(newElementName + UmlToCifTranslator.START_ACTION_SUFFIX);
 
                         // Store the finalized UML element in the synthesis chain tracker.
                         tracker.addFinalizedUmlElement(action, action);
@@ -250,7 +251,7 @@ public class PostProcessActivity {
                         PokaYokeUmlProfileUtil.setGuard(action, PokaYokeUmlProfileUtil.getGuard(umlElement));
                         PokaYokeUmlProfileUtil.setEffects(action, PokaYokeUmlProfileUtil.getEffects(umlElement));
                         PokaYokeUmlProfileUtil.setAtomic(action, PokaYokeUmlProfileUtil.isAtomic(umlElement));
-                        action.setName(action.getName());
+                        action.setName(newElementName);
 
                         // Store the finalized UML element in the synthesis chain tracker.
                         tracker.addFinalizedUmlElement(action, action);
@@ -262,7 +263,7 @@ public class PostProcessActivity {
                         // call. Add the original UML element's guard. Set the atomicity property to 'true'.
                         PokaYokeUmlProfileUtil.setGuard(action, PokaYokeUmlProfileUtil.getGuard(umlElement));
                         PokaYokeUmlProfileUtil.setAtomic(action, true);
-                        action.setName(action.getName() + UmlToCifTranslator.START_ACTION_SUFFIX);
+                        action.setName(newElementName + UmlToCifTranslator.START_ACTION_SUFFIX);
 
                         // Store the finalized UML element in the synthesis chain tracker.
                         tracker.addFinalizedUmlElement(action, action);
@@ -281,10 +282,11 @@ public class PostProcessActivity {
 
                         // The action is the end of a non-merged non-atomic UML element. Rename the current action,
                         // set the atomicity property to 'true', set its guard to 'true', and retain the original
-                        // relevant effect.
+                        // relevant effect. In the renaming we use (effectIdx + 1) because the tracker is 0-indexed
+                        // while the actions names are 1-indexed.
                         int effectIdx = tracker.getEffectIdx(action);
-                        action.setName(action.getName().replace(UmlToCifTranslator.NONATOMIC_OUTCOME_SUFFIX,
-                                UmlToCifTranslator.END_ACTION_SUFFIX));
+                        action.setName(
+                                newElementName + UmlToCifTranslator.END_ACTION_SUFFIX + String.valueOf(effectIdx + 1));
                         PokaYokeUmlProfileUtil.setAtomic(action, true);
                         PokaYokeUmlProfileUtil.setGuard(action, "true");
 
@@ -319,6 +321,21 @@ public class PostProcessActivity {
             {
                 throw new RuntimeException("Found unexpected node type: " + node.getClass().getSimpleName());
             }
+        }
+    }
+
+    /**
+     * Creates a new name for the given UML element and its container activity, without the use of double underscores.
+     *
+     * @param umlElement The UML element to rename.
+     * @param activity The container activity.
+     * @return The new element's name.
+     */
+    private static String getNewElementName(RedefinableElement umlElement, Activity activity) {
+        if (umlElement instanceof OpaqueBehavior || umlElement.eContainer().equals(activity)) {
+            return umlElement.getName();
+        } else {
+            return ((Activity)umlElement.eContainer()).getName() + "_" + umlElement.getName();
         }
     }
 }

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/PostProcessActivity.java
@@ -338,7 +338,7 @@ public class PostProcessActivity {
      * @return The new element's name.
      */
     private static String getNewElementName(RedefinableElement umlElement, Activity synthesizedActivity) {
-        Verify.verify(!umlElement.getName().contains("__"),
+        Preconditions.checkArgument(!umlElement.getName().contains("__"),
                 "The name of UML element " + umlElement.getName() + " contains double underscores.");
 
         if (umlElement.eContainer() instanceof Activity activity && !activity.equals(synthesizedActivity)) {

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/DoubleMergePattern.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/DoubleMergePattern.java
@@ -15,16 +15,22 @@ import java.util.Optional;
 
 import org.eclipse.uml2.uml.Activity;
 import org.eclipse.uml2.uml.ActivityEdge;
+import org.eclipse.uml2.uml.ActivityFinalNode;
 import org.eclipse.uml2.uml.ActivityNode;
+import org.eclipse.uml2.uml.ControlFlow;
 import org.eclipse.uml2.uml.MergeNode;
+
+import com.github.tno.pokayoke.transform.track.SynthesisChainTracking;
+import com.github.tno.synthml.uml.profile.util.PokaYokeUmlProfileUtil;
 
 /**
  * Functionality for finding and replacing <i>double merge</i> patterns in UML activities.
  * <p>
- * A <i>double merge</i> pattern is a control flow in the UML activity that connects two merge nodes. Such a control
- * flow is redundant since all the merging that's done on the source merge node can also be done on the target merge
- * node. Every such control flow can thus be rewritten by removing the source merge node, and redirecting all merging
- * control flows to merge into the target merge node instead.
+ * A <i>double merge</i> pattern is a control flow with trivial guards in the UML activity that connects two merge
+ * nodes, where none of them corresponds to the translation of an activity final node of a called concrete activity.
+ * Such a control flow is redundant since all the merging that's done on the source merge node can also be done on the
+ * target merge node. Every such control flow can thus be rewritten by removing the source merge node, and redirecting
+ * all merging control flows to merge into the target merge node instead.
  * </p>
  */
 public class DoubleMergePattern {
@@ -38,14 +44,15 @@ public class DoubleMergePattern {
      * Finds and rewrites all <i>double merge</i> patterns in the given activity.
      *
      * @param activity The input activity, which is modified in-place.
+     * @param tracker The synthesis chain tracker.
      * @return {@code true} if the input activity has been rewritten, {@code false} otherwise.
      */
-    public static boolean findAndRewriteAll(Activity activity) {
+    public static boolean findAndRewriteAll(Activity activity, SynthesisChainTracking tracker) {
         boolean hasFoundPatterns = false;
 
         // Only rewrite one pattern at a time, to prevent issues when patterns overlap.
         while (true) {
-            Optional<DoubleMergePattern> patterns = findAny(activity);
+            Optional<DoubleMergePattern> patterns = findAny(activity, tracker);
             if (patterns.isEmpty()) {
                 break;
             } else {
@@ -60,20 +67,27 @@ public class DoubleMergePattern {
      * Finds a <i>double merge</i> pattern in the given activity, if present.
      *
      * @param activity The input activity.
+     * @param tracker The synthesis chain tracker.
      * @return A <i>double merge</i> pattern in the given activity, if present.
      */
-    public static Optional<DoubleMergePattern> findAny(Activity activity) {
-        return activity.getEdges().stream().flatMap(edge -> findAny(edge).stream()).findFirst();
+    public static Optional<DoubleMergePattern> findAny(Activity activity, SynthesisChainTracking tracker) {
+        return activity.getEdges().stream().flatMap(edge -> findAny(edge, tracker).stream()).findFirst();
     }
 
     /**
      * Tries finding a <i>double merge</i> pattern that involves the given control flow.
      *
      * @param controlFlow The input control flow.
+     * @param tracker The synthesis chain tracker.
      * @return Some <i>double merge</i> pattern in case one was found, or an empty result otherwise.
      */
-    private static Optional<DoubleMergePattern> findAny(ActivityEdge controlFlow) {
-        if (controlFlow.getSource() instanceof MergeNode && controlFlow.getTarget() instanceof MergeNode) {
+    private static Optional<DoubleMergePattern> findAny(ActivityEdge controlFlow, SynthesisChainTracking tracker) {
+        if (controlFlow.getSource() instanceof MergeNode sourceMergeNode
+                && controlFlow.getTarget() instanceof MergeNode targetMergeNode
+                && !(tracker.getOriginalUmlElement(sourceMergeNode) instanceof ActivityFinalNode)
+                && !(tracker.getOriginalUmlElement(targetMergeNode) instanceof ActivityFinalNode)
+                && !PokaYokeUmlProfileUtil.isGuardedControlFlow((ControlFlow)controlFlow))
+        {
             return Optional.of(new DoubleMergePattern(controlFlow));
         } else {
             return Optional.empty();

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/EquivalentActionsIntoMergePattern.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/EquivalentActionsIntoMergePattern.java
@@ -17,21 +17,24 @@ import java.util.Optional;
 import org.eclipse.uml2.uml.Action;
 import org.eclipse.uml2.uml.Activity;
 import org.eclipse.uml2.uml.ActivityEdge;
+import org.eclipse.uml2.uml.ActivityFinalNode;
 import org.eclipse.uml2.uml.ActivityNode;
 import org.eclipse.uml2.uml.ControlFlow;
 import org.eclipse.uml2.uml.MergeNode;
 import org.eclipse.uml2.uml.UMLFactory;
 
+import com.github.tno.pokayoke.transform.track.SynthesisChainTracking;
 import com.github.tno.synthml.uml.profile.util.PokaYokeUmlProfileUtil;
 import com.google.common.base.Preconditions;
 
 /**
  * Functionality for finding and rewriting <i>equivalent actions into merge</i> patterns in UML activities.
  * <p>
- * An <i>equivalent actions into merge</i> pattern is a pattern consisting of a merge node, which merges equivalent
- * action nodes. Such a pattern is redundant since the merge node could be 'pushed upwards' so that only a single such
- * action node would be needed. Every such pattern can be rewritten by 'pushing upwards' the merge node and eliminating
- * the redundant action nodes.
+ * An <i>equivalent actions into merge</i> pattern is a pattern consisting of a merge node, which does not correspond to
+ * the translation of an activity final node of a called concrete activity, which merges equivalent action nodes, and
+ * the related control flows have trivial guards. Such a pattern is redundant since the merge node could be 'pushed
+ * upwards' so that only a single such action node would be needed. Every such pattern can be rewritten by 'pushing
+ * upwards' the merge node and eliminating the redundant action nodes.
  * </p>
  */
 public class EquivalentActionsIntoMergePattern {
@@ -53,10 +56,11 @@ public class EquivalentActionsIntoMergePattern {
      * Finds and rewrites all <i>equivalent actions into merge</i> patterns in the given activity.
      *
      * @param activity The input activity, which is modified in-place.
+     * @param tracker The synthesis chain tracker.
      * @return {@code true} if the input activity has been rewritten, {@code false} otherwise.
      */
-    public static boolean findAndRewriteAll(Activity activity) {
-        List<EquivalentActionsIntoMergePattern> patterns = findAll(activity);
+    public static boolean findAndRewriteAll(Activity activity, SynthesisChainTracking tracker) {
+        List<EquivalentActionsIntoMergePattern> patterns = findAll(activity, tracker);
         patterns.forEach(EquivalentActionsIntoMergePattern::rewrite);
         return patterns.size() > 0;
     }
@@ -65,25 +69,34 @@ public class EquivalentActionsIntoMergePattern {
      * Finds all <i>equivalent actions into merge</i> patterns in the given activity.
      *
      * @param activity The input activity.
+     * @param tracker The synthesis chain tracker.
      * @return All <i>equivalent actions into merge</i> patterns in the given activity.
      */
-    public static List<EquivalentActionsIntoMergePattern> findAll(Activity activity) {
-        return activity.getNodes().stream().flatMap(node -> findAny(node).stream()).toList();
+    public static List<EquivalentActionsIntoMergePattern> findAll(Activity activity, SynthesisChainTracking tracker) {
+        return activity.getNodes().stream().flatMap(node -> findAny(node, tracker).stream()).toList();
     }
 
     /**
      * Tries finding an <i>equivalent actions into merge</i> pattern that involves the given activity node.
      *
      * @param node The input activity node.
+     * @param tracker The synthesis chain tracker.
      * @return Some <i>equivalent actions into merge</i> pattern in case one was found, or an empty result otherwise.
      */
-    private static Optional<EquivalentActionsIntoMergePattern> findAny(ActivityNode node) {
-        if (node instanceof MergeNode mergeNode && mergeNode.getIncomings().size() > 1) {
+    private static Optional<EquivalentActionsIntoMergePattern> findAny(ActivityNode node,
+            SynthesisChainTracking tracker)
+    {
+        if (node instanceof MergeNode mergeNode
+                && !(tracker.getOriginalUmlElement(mergeNode) instanceof ActivityFinalNode)
+                && mergeNode.getIncomings().size() > 1)
+        {
             List<Action> incomingActions = new ArrayList<>(node.getIncomings().size());
 
             for (ActivityEdge controlFlow: node.getIncomings()) {
-                if (controlFlow.getSource() instanceof Action action && (incomingActions.isEmpty()
-                        || PokaYokeUmlProfileUtil.areEquivalent(action, incomingActions.get(0))))
+                if (controlFlow.getSource() instanceof Action action
+                        && !PokaYokeUmlProfileUtil.isGuardedControlFlow((ControlFlow)controlFlow)
+                        && (incomingActions.isEmpty()
+                                || PokaYokeUmlProfileUtil.areEquivalent(action, incomingActions.get(0))))
                 {
                     incomingActions.add(action);
                 } else {

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionForkMergePattern.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionForkMergePattern.java
@@ -18,21 +18,27 @@ import java.util.stream.Collectors;
 
 import org.eclipse.uml2.uml.Activity;
 import org.eclipse.uml2.uml.ActivityEdge;
+import org.eclipse.uml2.uml.ActivityFinalNode;
 import org.eclipse.uml2.uml.ActivityNode;
+import org.eclipse.uml2.uml.ControlFlow;
 import org.eclipse.uml2.uml.DecisionNode;
 import org.eclipse.uml2.uml.ForkNode;
+import org.eclipse.uml2.uml.InitialNode;
 import org.eclipse.uml2.uml.MergeNode;
 import org.eclipse.uml2.uml.UMLFactory;
 
+import com.github.tno.pokayoke.transform.track.SynthesisChainTracking;
+import com.github.tno.synthml.uml.profile.util.PokaYokeUmlProfileUtil;
 import com.google.common.base.Preconditions;
 
 /**
  * Functionality for finding and rewriting redundant decision-fork-merge patterns in UML activities.
  * <p>
  * A <i>redundant decision-fork-merge pattern</i> is a pattern where, after doing some decision node, the activity
- * branches into <i>N</i> different paths, which all fork and all merge again into the same <i>N</i> merge nodes. This
- * pattern is redundant, since the decision node and all <i>N</i> fork and merge nodes can be replaced by a single fork
- * node.
+ * branches into <i>N</i> different paths, which all fork and all merge again into the same <i>N</i> merge nodes, and
+ * all control flows in between have trivial guards. Further, The decision and merge node must not correspond to the
+ * translation of a concrete activity initial and final nodes, respectively. This pattern is redundant, since the
+ * decision node and all <i>N</i> fork and merge nodes can be replaced by a single fork node.
  * </p>
  */
 public class RedundantDecisionForkMergePattern {
@@ -56,10 +62,11 @@ public class RedundantDecisionForkMergePattern {
      * Finds and rewrites all redundant decision-fork-merge patterns in the given activity.
      *
      * @param activity The input activity, which is modified in-place.
+     * @param tracker The synthesis chain tracker.
      * @return {@code true} if the input activity has been rewritten, {@code false} otherwise.
      */
-    public static boolean findAndRewriteAll(Activity activity) {
-        List<RedundantDecisionForkMergePattern> patterns = findAll(activity);
+    public static boolean findAndRewriteAll(Activity activity, SynthesisChainTracking tracker) {
+        List<RedundantDecisionForkMergePattern> patterns = findAll(activity, tracker);
         patterns.forEach(RedundantDecisionForkMergePattern::rewrite);
         return patterns.size() > 0;
     }
@@ -68,37 +75,51 @@ public class RedundantDecisionForkMergePattern {
      * Finds all redundant decision-fork-merge patterns in the given activity.
      *
      * @param activity The input activity.
+     * @param tracker The synthesis chain tracker.
      * @return All redundant decision-fork-merge patterns in the given activity.
      */
-    public static List<RedundantDecisionForkMergePattern> findAll(Activity activity) {
-        return activity.getNodes().stream().flatMap(node -> findAny(node).stream()).toList();
+    public static List<RedundantDecisionForkMergePattern> findAll(Activity activity, SynthesisChainTracking tracker) {
+        return activity.getNodes().stream().flatMap(node -> findAny(node, tracker).stream()).toList();
     }
 
     /**
      * Tries finding a redundant decision-fork-merge pattern that starts from the given activity node.
      *
      * @param node The input activity node.
+     * @param tracker The synthesis chain tracker.
      * @return Some redundant decision-fork-merge pattern in case one was found, or an empty result otherwise.
      */
-    private static Optional<RedundantDecisionForkMergePattern> findAny(ActivityNode node) {
-        // If the given node is not a decision node, then it does not start a redundant decision-fork-merge pattern.
-        if (node instanceof DecisionNode decisionNode) {
+    private static Optional<RedundantDecisionForkMergePattern> findAny(ActivityNode node,
+            SynthesisChainTracking tracker)
+    {
+        // To start a redundant decision-fork-merge pattern, the node must be a decision node that does not correspond
+        // to an initial node of a called concrete activity.
+        if (node instanceof DecisionNode decisionNode
+                && !(tracker.getOriginalUmlElement(decisionNode) instanceof InitialNode))
+        {
             int nrOfOutgoings = decisionNode.getOutgoings().size();
 
-            // Find the set of all target nodes of the decision node, and check whether these are all fork nodes.
-            Set<ForkNode> forkNodes = decisionNode.getOutgoings().stream().map(ActivityEdge::getTarget)
-                    .filter(ForkNode.class::isInstance).map(ForkNode.class::cast)
+            // Find the set of all target nodes of the decision node, and check whether these are all fork nodes. The
+            // control flow should also have no guard.
+            Set<ForkNode> forkNodes = decisionNode.getOutgoings().stream()
+                    .filter(e -> !PokaYokeUmlProfileUtil.isGuardedControlFlow((ControlFlow)e))
+                    .map(ActivityEdge::getTarget).filter(ForkNode.class::isInstance).map(ForkNode.class::cast)
                     .collect(Collectors.toCollection(LinkedHashSet::new));
 
             if (forkNodes.size() == nrOfOutgoings) {
-                // Iterate over every fork node and: (1) find the set of all target nodes, (2) check whether the number
-                // of target nodes is the same as the number of fork nodes, (3) check whether all target nodes are merge
-                // nodes, (4) check whether all fork nodes that we previously iterated over target the same merge nodes.
+                // Iterate over every fork node and:
+                // (1) find the set of all target merge nodes connected by a control flow without guards, and that do
+                // not correspond to the translation of an activity final node of a called concrete activity,
+                // (2) check whether the number of target nodes is the same as the number of fork nodes,
+                // (3) check whether all target nodes are merge nodes,
+                // (4) check whether all fork nodes that we previously iterated over target the same merge nodes.
                 Set<MergeNode> mergeNodes = new LinkedHashSet<>();
 
                 for (ForkNode forkNode: forkNodes) {
-                    Set<MergeNode> localMergeNodes = forkNode.getOutgoings().stream().map(ActivityEdge::getTarget)
-                            .filter(MergeNode.class::isInstance).map(MergeNode.class::cast)
+                    Set<MergeNode> localMergeNodes = forkNode.getOutgoings().stream()
+                            .filter(e -> !PokaYokeUmlProfileUtil.isGuardedControlFlow((ControlFlow)e))
+                            .map(ActivityEdge::getTarget).filter(MergeNode.class::isInstance).map(MergeNode.class::cast)
+                            .filter(m -> !(tracker.getOriginalUmlElement(m) instanceof ActivityFinalNode))
                             .collect(Collectors.toCollection(LinkedHashSet::new));
 
                     if (forkNode.getOutgoings().size() != localMergeNodes.size()

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionForkMergePattern.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionForkMergePattern.java
@@ -111,7 +111,7 @@ public class RedundantDecisionForkMergePattern {
                 // (1) find the set of all target merge nodes connected by a control flow without guards, and that do
                 // not correspond to the translation of an activity final node of a called concrete activity,
                 // (2) check whether the number of target nodes is the same as the number of fork nodes,
-                // (3) check whether all target nodes are merge nodes,
+                // (3) check whether all target nodes are merge nodes, and
                 // (4) check whether all fork nodes that we previously iterated over target the same merge nodes.
                 Set<MergeNode> mergeNodes = new LinkedHashSet<>();
 

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionMergePattern.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionMergePattern.java
@@ -18,10 +18,15 @@ import java.util.stream.Collectors;
 
 import org.eclipse.uml2.uml.Activity;
 import org.eclipse.uml2.uml.ActivityEdge;
+import org.eclipse.uml2.uml.ActivityFinalNode;
 import org.eclipse.uml2.uml.ActivityNode;
+import org.eclipse.uml2.uml.ControlFlow;
 import org.eclipse.uml2.uml.DecisionNode;
+import org.eclipse.uml2.uml.InitialNode;
 import org.eclipse.uml2.uml.MergeNode;
 
+import com.github.tno.pokayoke.transform.track.SynthesisChainTracking;
+import com.github.tno.synthml.uml.profile.util.PokaYokeUmlProfileUtil;
 import com.google.common.base.Preconditions;
 
 /**
@@ -29,9 +34,10 @@ import com.google.common.base.Preconditions;
  * <p>
  * A <i>redundant decision-merge pattern</i> is a pattern where the activity branches and after that directly merges.
  * This pattern consists of a decision node and a merge node, such that all control flows from the decision node go
- * directly to the merge node, with nothing in between. Every such pattern can be rewritten by removing the decision
- * node and possibly the merge node (depending on whether it has other incoming control flows), and redirecting the
- * outgoing control flow of the decision node to the proper target node.
+ * directly to the merge node, have only trivial guards, with nothing in between. Further, The decision and merge node
+ * must not correspond to the translation of a concrete activity initial and final nodes, respectively. Every such
+ * pattern can be rewritten by removing the decision node and possibly the merge node (depending on whether it has other
+ * incoming control flows), and redirecting the outgoing control flow of the decision node to the proper target node.
  * </p>
  */
 public class RedundantDecisionMergePattern {
@@ -48,10 +54,11 @@ public class RedundantDecisionMergePattern {
      * Finds and rewrites all redundant decision-merge patterns in the given activity.
      *
      * @param activity The input activity, which is modified in-place.
+     * @param tracker The synthesis chain tracker.
      * @return {@code true} if the input activity has been rewritten, {@code false} otherwise.
      */
-    public static boolean findAndRewriteAll(Activity activity) {
-        List<RedundantDecisionMergePattern> patterns = findAll(activity);
+    public static boolean findAndRewriteAll(Activity activity, SynthesisChainTracking tracker) {
+        List<RedundantDecisionMergePattern> patterns = findAll(activity, tracker);
         patterns.forEach(RedundantDecisionMergePattern::rewrite);
         return patterns.size() > 0;
     }
@@ -60,27 +67,36 @@ public class RedundantDecisionMergePattern {
      * Finds all redundant decision-merge patterns in the given activity.
      *
      * @param activity The input activity.
+     * @param tracker The synthesis chain tracker.
      * @return All redundant decision-merge patterns in the given activity.
      */
-    public static List<RedundantDecisionMergePattern> findAll(Activity activity) {
-        return activity.getNodes().stream().flatMap(node -> findAny(node).stream()).toList();
+    public static List<RedundantDecisionMergePattern> findAll(Activity activity, SynthesisChainTracking tracker) {
+        return activity.getNodes().stream().flatMap(node -> findAny(node, tracker).stream()).toList();
     }
 
     /**
      * Tries finding a redundant decision-merge pattern that starts from the given activity node.
      *
      * @param node The input activity node.
+     * @param tracker The synthesis chain tracker.
      * @return Some redundant decision-merge pattern in case one was found, or an empty result otherwise.
      */
-    private static Optional<RedundantDecisionMergePattern> findAny(ActivityNode node) {
-        // If the given node is not a decision node, then it does not start a redundant decision-merge pattern.
-        if (node instanceof DecisionNode decisionNode) {
+    private static Optional<RedundantDecisionMergePattern> findAny(ActivityNode node, SynthesisChainTracking tracker) {
+        // To start a redundant decision-merge pattern the node must be a decision node that does not correspond to a
+        // called concrete activity initial node.
+        if (node instanceof DecisionNode decisionNode
+                && !(tracker.getOriginalUmlElement(node) instanceof InitialNode))
+        {
             // Find the set of all target nodes that are reachable from the decision node by a control flow.
             Set<ActivityNode> targetNodes = decisionNode.getOutgoings().stream().map(ActivityEdge::getTarget)
                     .collect(Collectors.toCollection(LinkedHashSet::new));
 
-            // If there is exactly one target node which is a merge node, then we have found a pattern.
-            if (targetNodes.size() == 1 && targetNodes.iterator().next() instanceof MergeNode mergeNode) {
+            // If there is exactly one target node which is a merge node, which does not correspond to an activity final
+            // node, and the control flow does not have any guard, then we have found a pattern.
+            if (targetNodes.size() == 1 && targetNodes.iterator().next() instanceof MergeNode mergeNode
+                    && !(tracker.getOriginalUmlElement(mergeNode) instanceof ActivityFinalNode)
+                    && !PokaYokeUmlProfileUtil.isGuardedControlFlow((ControlFlow)decisionNode.getOutgoings().get(0)))
+            {
                 return Optional.of(new RedundantDecisionMergePattern(decisionNode, mergeNode));
             }
         }

--- a/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionMergePattern.java
+++ b/plugins/com.github.tno.pokayoke.transform.petrify2uml/src/com/github/tno/pokayoke/transform/petrify2uml/patterns/RedundantDecisionMergePattern.java
@@ -35,7 +35,7 @@ import com.google.common.base.Preconditions;
  * A <i>redundant decision-merge pattern</i> is a pattern where the activity branches and after that directly merges.
  * This pattern consists of a decision node and a merge node, such that all control flows from the decision node go
  * directly to the merge node, have only trivial guards, with nothing in between. Further, The decision and merge node
- * must not correspond to the translation of a concrete activity initial and final nodes, respectively. Every such
+ * must not correspond to the translation of a concrete activity initial and final node, respectively. Every such
  * pattern can be rewritten by removing the decision node and possibly the merge node (depending on whether it has other
  * incoming control flows), and redirecting the outgoing control flow of the decision node to the proper target node.
  * </p>

--- a/plugins/com.github.tno.synthml.uml.profile.util/src/com/github/tno/synthml/uml/profile/util/PokaYokeUmlProfileUtil.java
+++ b/plugins/com.github.tno.synthml.uml.profile.util/src/com/github/tno/synthml/uml/profile/util/PokaYokeUmlProfileUtil.java
@@ -152,7 +152,7 @@ public class PokaYokeUmlProfileUtil {
      * Returns {@code true} if the control flow has non-trivial (i.e. null or true) guards.
      *
      * @param controlFlow The control flow to interrogate.
-     * @return {@code true} if the control flow has non-trivial guards.
+     * @return {@code true} if the control flow has non-trivial guards, {@code false} otherwise.
      */
     public static boolean isGuardedControlFlow(ControlFlow controlFlow) {
         return !ExprHelper.isNullOrTriviallyTrue(PokaYokeUmlProfileUtil.getIncomingGuard(controlFlow))

--- a/plugins/com.github.tno.synthml.uml.profile.util/src/com/github/tno/synthml/uml/profile/util/PokaYokeUmlProfileUtil.java
+++ b/plugins/com.github.tno.synthml.uml.profile.util/src/com/github/tno/synthml/uml/profile/util/PokaYokeUmlProfileUtil.java
@@ -45,6 +45,7 @@ import org.eclipse.uml2.uml.UMLFactory;
 import org.eclipse.uml2.uml.UMLPlugin;
 import org.eclipse.uml2.uml.ValueSpecification;
 
+import com.github.tno.pokayoke.transform.common.ExprHelper;
 import com.github.tno.pokayoke.transform.common.FileHelper;
 import com.google.common.base.Strings;
 import com.google.common.base.Verify;
@@ -145,6 +146,17 @@ public class PokaYokeUmlProfileUtil {
 
     public static boolean isGuardEffectsAction(Action action) {
         return isSetGuard(action) || isSetEffects(action);
+    }
+
+    /**
+     * Returns {@code true} if the control flow has non-trivial (i.e. null or true) guards.
+     *
+     * @param controlFlow The control flow to interrogate.
+     * @return {@code true} if the control flow has non-trivial guards.
+     */
+    public static boolean isGuardedControlFlow(ControlFlow controlFlow) {
+        return !ExprHelper.isNullOrTriviallyTrue(PokaYokeUmlProfileUtil.getIncomingGuard(controlFlow))
+                || !ExprHelper.isNullOrTriviallyTrue(PokaYokeUmlProfileUtil.getOutgoingGuard(controlFlow));
     }
 
     public static boolean isSetGuard(RedefinableElement element) {


### PR DESCRIPTION
Update the finalization of opaque actions (step 15 of the synthesis chain). Renames UML nodes to remove double underscores (which will cause issues in later steps of the synthesis chain).
Updates the simplifications of the synthesis chain (step 17) to deal with concrete elements, namely control flows with non-trivial guards and decision/merge nodes which represent initial/final nodes of concrete activities.
Closes #629. Addresses #410. 